### PR TITLE
CRDL-174 Add the Bearer prefix to the expected EIS bearer token value

### DIFF
--- a/app/uk/gov/hmrc/centralreferencedataeisstub/controllers/InboundController.scala
+++ b/app/uk/gov/hmrc/centralreferencedataeisstub/controllers/InboundController.scala
@@ -59,7 +59,7 @@ class InboundController @Inject() (appConfig: AppConfig, cc: ControllerComponent
       case a @ _                                                                        => false
 
   private def validateBearerToken(headers: Headers): Boolean =
-    headers.get(AUTHORIZATION).getOrElse(UNAUTHORIZED) == appConfig.bearerToken
+    headers.get(AUTHORIZATION).contains(s"Bearer ${appConfig.bearerToken}")
 
   private def validateRequestBody(body: NodeSeq) =
     Try {

--- a/it/test/uk/gov/hmrc/centralreferencedataeisstub/controllers/InboundControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/centralreferencedataeisstub/controllers/InboundControllerISpec.scala
@@ -60,7 +60,7 @@ class InboundControllerISpec
           .withHttpHeaders(
             HeaderNames.ACCEPT -> "application/xml",
             HeaderNames.CONTENT_TYPE -> "application/xml;charset=UTF-8",
-            HeaderNames.AUTHORIZATION -> appConfig.bearerToken,
+            HeaderNames.AUTHORIZATION -> s"Bearer ${appConfig.bearerToken}",
             HeaderNames.X_FORWARDED_HOST -> "some-host",
             "X-Correlation-Id" -> "some-correlation-id",
             HeaderNames.DATE -> "some-date"

--- a/test/uk/gov/hmrc/centralreferencedataeisstub/controllers/InboundControllerSpec.scala
+++ b/test/uk/gov/hmrc/centralreferencedataeisstub/controllers/InboundControllerSpec.scala
@@ -100,7 +100,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT           -> "application/xml",
             HeaderNames.CONTENT_TYPE     -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION    -> appConfig.bearerToken,
+            HeaderNames.AUTHORIZATION    -> s"Bearer ${appConfig.bearerToken}",
             HeaderNames.X_FORWARDED_HOST -> "some-host",
             "X-Correlation-Id"           -> "some-correlation-id",
             HeaderNames.DATE             -> "some-date"
@@ -115,7 +115,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
         fakeRequest
           .withHeaders(
             HeaderNames.CONTENT_TYPE  -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION -> appConfig.bearerToken
+            HeaderNames.AUTHORIZATION -> s"Bearer ${appConfig.bearerToken}"
           )
           .withBody(validTestBody)
       )
@@ -128,7 +128,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT        -> "application/text",
             HeaderNames.CONTENT_TYPE  -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION -> appConfig.bearerToken
+            HeaderNames.AUTHORIZATION -> s"Bearer ${appConfig.bearerToken}"
           )
           .withBody(validTestBody)
       )
@@ -140,7 +140,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
         fakeRequest
           .withHeaders(
             HeaderNames.ACCEPT        -> "application/xml",
-            HeaderNames.AUTHORIZATION -> appConfig.bearerToken
+            HeaderNames.AUTHORIZATION -> s"Bearer ${appConfig.bearerToken}"
           )
           .withBody(validTestBody)
       )
@@ -153,7 +153,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT        -> "application/xml",
             HeaderNames.CONTENT_TYPE  -> "application/text",
-            HeaderNames.AUTHORIZATION -> appConfig.bearerToken
+            HeaderNames.AUTHORIZATION -> s"Bearer ${appConfig.bearerToken}"
           )
           .withBody(validTestBody)
       )
@@ -166,7 +166,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT        -> "application/xml",
             HeaderNames.CONTENT_TYPE  -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION -> appConfig.bearerToken,
+            HeaderNames.AUTHORIZATION -> s"Bearer ${appConfig.bearerToken}",
             "X-Correlation-Id"        -> "some-correlation-id",
             HeaderNames.DATE          -> "some-date"
           )
@@ -181,7 +181,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT           -> "application/xml",
             HeaderNames.CONTENT_TYPE     -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION    -> appConfig.bearerToken,
+            HeaderNames.AUTHORIZATION    -> s"Bearer ${appConfig.bearerToken}",
             HeaderNames.X_FORWARDED_HOST -> "some-host",
             HeaderNames.DATE             -> "some-date"
           )
@@ -196,7 +196,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT           -> "application/xml",
             HeaderNames.CONTENT_TYPE     -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION    -> appConfig.bearerToken,
+            HeaderNames.AUTHORIZATION    -> s"Bearer ${appConfig.bearerToken}",
             HeaderNames.X_FORWARDED_HOST -> "some-host",
             "X-Correlation-Id"           -> "some-correlation-id"
           )
@@ -211,7 +211,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT           -> "application/xml",
             HeaderNames.CONTENT_TYPE     -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION    -> appConfig.bearerToken,
+            HeaderNames.AUTHORIZATION    -> s"Bearer ${appConfig.bearerToken}",
             HeaderNames.X_FORWARDED_HOST -> "some-host",
             "X-Correlation-Id"           -> "some-correlation-id",
             HeaderNames.DATE             -> "some-date"
@@ -227,7 +227,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT        -> "application/xml",
             HeaderNames.CONTENT_TYPE  -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION -> appConfig.bearerToken
+            HeaderNames.AUTHORIZATION -> s"Bearer ${appConfig.bearerToken}"
           )
           .withBody(invalidTestBody)
       )
@@ -240,7 +240,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT           -> "application/xml",
             HeaderNames.CONTENT_TYPE     -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION    -> appConfig.bearerToken,
+            HeaderNames.AUTHORIZATION    -> s"Bearer ${appConfig.bearerToken}",
             HeaderNames.X_FORWARDED_HOST -> "some-host",
             "X-Correlation-Id"           -> "some-correlation-id",
             HeaderNames.DATE             -> "some-date"
@@ -256,7 +256,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT           -> "application/xml",
             HeaderNames.CONTENT_TYPE     -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION    -> appConfig.bearerToken,
+            HeaderNames.AUTHORIZATION    -> s"Bearer ${appConfig.bearerToken}",
             HeaderNames.X_FORWARDED_HOST -> "some-host",
             "X-Correlation-Id"           -> "some-correlation-id",
             HeaderNames.DATE             -> "some-date"
@@ -272,7 +272,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT           -> "application/xml",
             HeaderNames.CONTENT_TYPE     -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION    -> appConfig.bearerToken,
+            HeaderNames.AUTHORIZATION    -> s"Bearer ${appConfig.bearerToken}",
             HeaderNames.X_FORWARDED_HOST -> "some-host",
             "X-Correlation-Id"           -> "some-correlation-id",
             HeaderNames.DATE             -> "some-date"
@@ -288,7 +288,7 @@ class InboundControllerSpec extends AnyWordSpec, GuiceOneAppPerSuite, Matchers:
           .withHeaders(
             HeaderNames.ACCEPT           -> "application/xml",
             HeaderNames.CONTENT_TYPE     -> "application/xml; charset=UTF-8",
-            HeaderNames.AUTHORIZATION    -> appConfig.bearerToken,
+            HeaderNames.AUTHORIZATION    -> s"Bearer ${appConfig.bearerToken}",
             HeaderNames.X_FORWARDED_HOST -> "some-host",
             "X-Correlation-Id"           -> "some-correlation-id",
             HeaderNames.DATE             -> "some-date"


### PR DESCRIPTION
As confirmed by the EIS team, we need to add the `Bearer ` prefix to the EIS bearer token. We can't store values with spaces as encrypted values in app-config-* secrets, so we need to add the prefix in our code.

This means that we now need to expect the prefix in this stub in order for the stub to accept requests from the inbound orchestrator as of https://github.com/hmrc/central-reference-data-inbound-orchestrator/pull/49.